### PR TITLE
Add first tools - logger and envcfg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+jobs:
+  build:
+    working_directory: /go/src/github.com/vivareal/ligeiro
+    docker:
+      - image: circleci/golang:1.9.2
+    steps:
+      - checkout
+      - run:
+          name: Download dependencies
+          command: go get github.com/sirupsen/logrus
+      - run:
+          name: Run specs with coverage and race condition check
+          command: go test -v -cover -race ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Make sure you have logrus in your go path:
+
+```
+go get github.com/sirupsen/logrus
+```
+
+After that just follow usual workflow of forking and opening pull request.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# Ligeiro
+
+![ligeiro](https://user-images.githubusercontent.com/379894/33691641-4a943e4e-dad0-11e7-846a-540dc7923d86.png)
+
+Minimalist tools for your golang applications.
+
+## Motivation
+
+After copy/pasting very often small pieces of code that rely on some conventions such as how to handle environment configurations, format logs according with company requirements a few times, it got painful to change everywhere when it need to change or have a new requirement.
+
+This library attempts to provide minimalist tools that you help your application to comply with some platform requirements such as configs, logs, etc.
+
+## Usage
+
+### Configs
+
+Basically pass a map of env vars with their respective defaults, it will be merged with bundled
+configs (ENVIRONMENT, LOG_LEVEL and VERSION):
+
+```go
+import (
+	"fmt"
+
+	"github.com/vivareal/ligeiro/envcfg"
+)
+
+func main() {
+	Config := envcfg.Load(envcfg.EnvCfgMap{
+		"APPLICATION": "myappname",
+		"LISTEN_PORT": ":8080",
+	})
+
+	fmt.Println(Config.Get("listenPort"))
+	fmt.Println(Config.Get("application"))
+	fmt.Println(Config.Get("logLevel"))
+}
+```
+
+Running previous file with LOG_LEVEL env var set:
+
+```
+$ LOG_LEVEL=error go run main.go
+
+:8080
+myappname
+error
+```
+
+### Logs
+
+Offers a thin wrapper to github.com/sirupsen/logrus to log GELF like format to stdout, ready to docker GELF drivers. The
+best way to use it to define your own `applog` package with custom fields registered:
+
+```go
+package myapi
+
+import "github.com/vivareal/ligeiro/logger"
+
+var Applog = logger.WithFields(logger.Fields{
+	"application": "myapi",
+	"squad":       "growth",
+})
+
+func example() {
+	Applog.Info("ligeiro")
+	// Output: {"application":"myapi","environment":"dev","fields.level":6,"full_message":"ligeiro","level":6,"level_name":"info","time":"2017-12-07T17:25:13-02:00","timestamp":1512674713370,"version":"detached"}
+}
+```
+
+Note: _`logger` already checks `envcfg` to add some custom fields to formatted log output_

--- a/envcfg/envcfg.go
+++ b/envcfg/envcfg.go
@@ -1,0 +1,91 @@
+// Load configs from environment handling defaults and expose them.
+package envcfg
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Type alias for environment variables configs, it maps `ENV_VAR` with `default_value`
+type Map map[string]string
+
+// Already provided environment variable, custom config overrides them.
+var bundledConfigs = Map{
+	"ENVIRONMENT": "dev",
+	"LOG_LEVEL":   "debug",
+	"VERSION":     "detached",
+}
+
+// Type that holds parsed config and expose them via Get()
+type config struct {
+	parsedConfigs Map
+}
+
+func (c *config) Get(key string) string {
+	if configValue, exists := c.parsedConfigs[key]; exists {
+		return configValue
+	} else {
+		fmt.Sprintf("Unexpected config, returning empty string: %v", key)
+		return ""
+	}
+}
+
+// Bundled configs (ENVIRONMENT, LOG_LEVEL and VERSION) only, useful for brand new applications that has no extra confs.
+func LoadBundled() *config {
+	return Load(Map{})
+}
+
+// Custom environment config map with bundled configs (first has higher priority). look at example for more details.
+// Best way to use is to create a config package with init() func that expose Load() result.
+func Load(environmentVariablesWithDefaults Map) *config {
+	parsedConfigs := Map{}
+
+	// Load bundledConfigs into custom ones only if custom not define them already
+	for environmentVariable, defaultValue := range bundledConfigs {
+		if _, exists := environmentVariablesWithDefaults[environmentVariable]; !exists {
+			environmentVariablesWithDefaults[environmentVariable] = defaultValue
+		}
+	}
+
+	// Parse merge custom and bundledConfigs fetching environment variables
+	for environmentVariable, defaultValue := range environmentVariablesWithDefaults {
+		parsedConfigs[toCamelCase(environmentVariable)] = getEnvVarWithDefault(environmentVariable, defaultValue)
+	}
+
+	return &config{parsedConfigs}
+}
+
+func getEnvVarWithDefault(env string, defaultValue string) string {
+	variable := defaultValue
+
+	if setValue := os.Getenv(env); setValue != "" {
+		variable = setValue
+	}
+
+	return variable
+}
+
+func toCamelCase(s string) string {
+	capitalizeNextChar := false
+	s = strings.Trim(strings.ToLower(s), " ")
+	camelized := ""
+
+	for _, char := range s {
+		switch {
+		case char >= 'A' && char <= 'Z':
+			camelized += string(char)
+		case char >= 'a' && char <= 'z':
+			if capitalizeNextChar {
+				camelized += strings.ToUpper(string(char))
+				capitalizeNextChar = false
+			} else {
+				camelized += string(char)
+			}
+		case char == '_' || char == ' ' || char == '-':
+			capitalizeNextChar = true
+		}
+	}
+
+	return camelized
+}

--- a/envcfg/envcfg_test.go
+++ b/envcfg/envcfg_test.go
@@ -1,0 +1,70 @@
+package envcfg
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	t.Log("Returns empty string for unknown configs")
+
+	c := &config{}
+
+	if c.Get("unknown") != "" {
+		t.Errorf("Unexpected value for unknown config")
+	}
+}
+
+func TestBundledConfigs(t *testing.T) {
+	t.Log("Returns default values for bundled configs")
+
+	config := LoadBundled()
+
+	if config.Get("version") != "detached" {
+		t.Errorf("==> Bundled config didn't load default: version")
+	}
+	if config.Get("logLevel") != "debug" {
+		t.Errorf("==> Bundled config didn't load default: logLevel")
+	}
+	if config.Get("environment") != "dev" {
+		t.Errorf("==> Bundled config didn't load default: environment")
+	}
+
+	t.Log("Returns environment set values for bundled configs")
+
+	os.Setenv("VERSION", "test")
+	config = LoadBundled()
+
+	if config.Get("version") != "test" {
+		t.Errorf("==> Bundled config didn't load environment value: version")
+	}
+	os.Unsetenv("VERSION") // Teardown
+}
+
+func TestCustomConfigs(t *testing.T) {
+	t.Log("Returns default values for custom configs")
+
+	config := Load(Map{"MY_ENV_VAR": "MY_VALUE"})
+
+	if config.Get("myEnvVar") != "MY_VALUE" {
+		t.Errorf("==> Custom config didn't load default: myEnvVar")
+	}
+
+	t.Log("Returns environment set values for custom configs")
+
+	os.Setenv("MY_ENV_VAR", "ligeiro")
+	config = Load(Map{"MY_ENV_VAR": "DEFAULT_VALUE"})
+
+	if config.Get("myEnvVar") != "ligeiro" {
+		t.Errorf("==> Custom config didn't load environment value: '%v'", config.Get("myEnvVar"))
+	}
+	os.Unsetenv("MY_ENV_VAR") // Teardown
+
+	t.Log("Returns default values for custom configs even when they have same name of bundled ones")
+
+	config = Load(Map{"LOG_LEVEL": "error"})
+
+	if config.Get("logLevel") != "error" {
+		t.Errorf("==> Bundled config default took precedence over custom ones: '%v'", config.Get("logLevel"))
+	}
+}

--- a/envcfg/example_envcfg_test.go
+++ b/envcfg/example_envcfg_test.go
@@ -1,0 +1,30 @@
+package envcfg_test
+
+import (
+	"fmt"
+
+	"github.com/vivareal/ligeiro/envcfg"
+)
+
+func ExampleLoad() {
+	Config := envcfg.Load(envcfg.Map{
+		"APPLICATION": "myappname",
+		"LISTEN_PORT": ":8080",
+	})
+
+	fmt.Println(Config.Get("listenPort"))
+	fmt.Println(Config.Get("logLevel"))
+	// Output:
+	// :8080
+	// debug
+}
+
+func ExampleLoadBundled() {
+	Config := envcfg.LoadBundled()
+
+	fmt.Println(Config.Get("version"))
+	fmt.Println(Config.Get("logLevel"))
+	// Output:
+	// detached
+	// debug
+}

--- a/ligeiro.go
+++ b/ligeiro.go
@@ -1,0 +1,5 @@
+// Minimalist tools for your golang applications.
+//
+// This library attempts to provide minimalist tools that you help your application to comply with some platform
+// requirements such as configs, logs, etc.
+package ligeiro

--- a/logger/example_logger_test.go
+++ b/logger/example_logger_test.go
@@ -1,0 +1,49 @@
+package logger_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vivareal/ligeiro/logger"
+)
+
+func ExampleInfo() {
+	var fields logrus.Fields
+	var buffer bytes.Buffer
+	logrus.SetOutput(&buffer)
+
+	logger.Info("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+
+	fmt.Println(fields["full_message"])
+	fmt.Println(fields["environment"])
+	fmt.Println(fields["version"])
+	// Output:
+	// Lorem Ipsum
+	// dev
+	// detached
+}
+
+func ExampleInfof() {
+	var fields logrus.Fields
+	var buffer bytes.Buffer
+	logrus.SetOutput(&buffer)
+
+	logger.WithFields(logger.Fields{"custom": "field"}).
+		Infof("Lorem %s", "Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+
+	fmt.Println(fields["full_message"])
+	fmt.Println(fields["environment"])
+	fmt.Println(fields["version"])
+	fmt.Println(fields["custom"])
+	// Output:
+	// Lorem Ipsum
+	// dev
+	// detached
+	// field
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,170 @@
+// Wrapper of logrus logging infrastructure.
+//
+// This package contains all the utilities to make logrus logging library attend
+// all requirements of VivaReal logging conventions described here https://github.com/VivaReal/platform/blob/master/Documentation/Logs/format.md
+//
+// It adds common fields as application, environment, process, product and version and provides a
+// simple API:
+//
+package logger
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vivareal/ligeiro/envcfg"
+)
+
+var config = envcfg.LoadBundled()
+
+type entry struct {
+	*logrus.Entry
+}
+
+type Fields logrus.Fields
+
+func init() {
+	logrus.SetLevel(levelFromString(config.Get("logLevel")))
+
+	logrus.SetFormatter(&logrus.JSONFormatter{
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyMsg:   "full_message",
+			logrus.FieldKeyLevel: "level_name",
+		},
+	})
+
+	logrus.RegisterExitHandler(func() {
+		Info("Application will stop probably due to a OS signal")
+	})
+
+	logrus.SetOutput(os.Stdout)
+}
+
+func WithFields(fields Fields) *entry {
+	fields["environment"] = config.Get("environment")
+	fields["version"] = config.Get("version")
+
+	return &entry{logrus.WithFields(logrus.Fields(fields))}
+}
+
+func Debug(msg interface{}) {
+	WithFields(Fields{}).Debug(msg)
+}
+
+func Debugf(format string, args ...interface{}) {
+	WithFields(Fields{}).Debug(fmt.Sprintf(format, args...))
+}
+
+func Info(msg interface{}) {
+	WithFields(Fields{}).Info(msg)
+}
+
+func Infof(format string, args ...interface{}) {
+	WithFields(Fields{}).Info(fmt.Sprintf(format, args...))
+}
+
+func Warn(msg interface{}) {
+	WithFields(Fields{}).Warn(msg)
+}
+
+func Warnf(format string, args ...interface{}) {
+	WithFields(Fields{}).Warn(fmt.Sprintf(format, args...))
+}
+
+func Error(msg interface{}) {
+	WithFields(Fields{}).Error(msg)
+}
+
+func Errorf(format string, args ...interface{}) {
+	WithFields(Fields{}).Error(fmt.Sprintf(format, args...))
+}
+
+func Fatal(msg interface{}) {
+	WithFields(Fields{}).Fatal(msg)
+}
+
+func Fatalf(format string, args ...interface{}) {
+	WithFields(Fields{}).Fatal(fmt.Sprintf(format, args...))
+}
+
+func Panic(msg interface{}) {
+	WithFields(Fields{}).Panic(msg)
+}
+
+func Panicf(format string, args ...interface{}) {
+	WithFields(Fields{}).Panic(fmt.Sprintf(format, args...))
+}
+
+func (entry *entry) Debug(msg interface{}) {
+	entry.Entry.
+		WithField("level", syslog.LOG_DEBUG).
+		WithField("timestamp", nowMillis()).
+		Debug(msg)
+}
+
+func (entry *entry) Info(msg interface{}) {
+	entry.Entry.
+		WithField("level", syslog.LOG_INFO).
+		WithField("timestamp", nowMillis()).
+		Info(msg)
+}
+
+func (entry *entry) Warn(msg interface{}) {
+	entry.Entry.
+		WithField("level", syslog.LOG_WARNING).
+		WithField("timestamp", nowMillis()).
+		Warn(msg)
+}
+
+func (entry *entry) Error(msg interface{}) {
+	entry.Entry.
+		WithField("level", syslog.LOG_ERR).
+		WithField("timestamp", nowMillis()).
+		Error(msg)
+}
+
+func (entry *entry) Fatal(msg interface{}) {
+	entry.Entry.
+		WithField("level", syslog.LOG_CRIT).
+		WithField("timestamp", nowMillis()).
+		Fatal(msg)
+}
+
+func (entry *entry) Panic(msg interface{}) {
+	entry.Entry.
+		WithField("level", syslog.LOG_EMERG).
+		WithField("timestamp", nowMillis()).
+		Panic(msg)
+}
+
+func (e *entry) WithFields(fields Fields) *entry {
+	return &entry{e.Entry.WithFields(logrus.Fields(fields))}
+}
+
+// Convert the level string to a logrusrus Level. E.g. "panic" becomes "PanicLevel".
+func levelFromString(level string) logrus.Level {
+	switch level {
+	case "debug":
+		return logrus.DebugLevel
+	case "info":
+		return logrus.InfoLevel
+	case "warning":
+		return logrus.WarnLevel
+	case "error":
+		return logrus.ErrorLevel
+	case "fatal":
+		return logrus.FatalLevel
+	case "panic":
+		return logrus.PanicLevel
+	default:
+		return logrus.DebugLevel
+	}
+}
+
+// Unix timestamp in milliseconds resolution
+func nowMillis() int64 {
+	return time.Now().UnixNano() / int64(time.Millisecond)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,93 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestLoggerLevel(t *testing.T) {
+	t.Log("Log with respective level (DEBUG, INFO, WARN, ERROR, FATAL, PANIC)")
+
+	var fields logrus.Fields
+	var buffer bytes.Buffer
+
+	logrus.SetOutput(&buffer)
+
+	Debug("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+	if fields["level"] != float64(7) {
+		t.Errorf("Wrong level from debug method: %s", fields["level"])
+	}
+
+	buffer.Reset()
+	Info("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+	if fields["level"] != float64(6) {
+		t.Errorf("Wrong level from info method: %s", fields["level"])
+	}
+
+	buffer.Reset()
+	Warn("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+	if fields["level"] != float64(4) {
+		t.Errorf("Wrong level from warn method: %s", fields["level"])
+	}
+
+	buffer.Reset()
+	Error("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+	if fields["level"] != float64(3) {
+		t.Errorf("Wrong level from error method: %s", fields["level"])
+	}
+}
+
+func TestLoggerCustomFields(t *testing.T) {
+	t.Log("Log with custom fields")
+
+	var fields logrus.Fields
+	var buffer bytes.Buffer
+
+	logrus.SetOutput(&buffer)
+	customFields := WithFields(Fields{"application": "myapp"})
+
+	customFields.Debug("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+	if fields["application"] != "myapp" {
+		t.Errorf("Custom field not logged")
+	}
+
+	buffer.Reset()
+	fields = logrus.Fields{}
+	customFields.Info("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+	if fields["application"] != "myapp" {
+		t.Errorf("Custom field not logged")
+	}
+
+	buffer.Reset()
+	fields = logrus.Fields{}
+	customFields.Warn("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+	if fields["application"] != "myapp" {
+		t.Errorf("Custom field not logged")
+	}
+
+	buffer.Reset()
+	fields = logrus.Fields{}
+	customFields.Error("Lorem Ipsum")
+
+	json.Unmarshal(buffer.Bytes(), &fields)
+	if fields["application"] != "myapp" {
+		t.Errorf("Custom field not logged")
+	}
+}


### PR DESCRIPTION
All Go applications of growth squad here in VivaReal uses configs e logs
at the same way. After copy/pasting very often small pieces of code that
rely on some conventions such as how to handle environment configurations,
format logs according with company requirements a few times, it got painful
to change everywhere when it need to change or have a new requirement.

This commit adds `logger` and `envcfg` to hold this knowledge,
both subpackages are extremely simple:

```go
import (
	"fmt"

	"github.com/vivareal/ligeiro/envcfg"
)

func main() {
	Config := envcfg.Load(envcfg.EnvCfgMap{
		"APPLICATION": "myappname",
		"LISTEN_PORT": ":8080",
	})

	fmt.Println(Config.Get("listenPort"))
	fmt.Println(Config.Get("application"))
	fmt.Println(Config.Get("logLevel"))
}
```

Running previous file with LOG_LEVEL env var set:

```
$ LOG_LEVEL=error go run main.go

:8080
myappname
error
```

Offers a thin wrapper to github.com/sirupsen/logrus to log GELF like format to stdout, ready to docker GELF drivers. The
best way to use it to define your own `applog` package with custom fields registered:

```go
package myapi

import "github.com/vivareal/ligeiro/logger"

var Applog = logger.WithFields(logger.Fields{
	"application": "myapi",
	"squad":       "growth",
})

func example() {
	Applog.Info("ligeiro")
	// Output: {"application":"myapi","environment":"dev","fields.level":6,"full_message":"ligeiro","level":6,"level_name":"info","time":"2017-12-07T17:25:13-02:00","timestamp":1512674713370,"version":"detached"}
}
```