### PR TITLE
Add `envcfg.GetInt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ func main() {
 	Config := envcfg.Load(envcfg.EnvCfgMap{
 		"APPLICATION": "myappname",
 		"LISTEN_PORT": ":8080",
+		"MAX_BYTES": "3000000"
 	})
 
 	fmt.Println(Config.Get("listenPort"))
 	fmt.Println(Config.Get("application"))
 	fmt.Println(Config.Get("logLevel"))
+	fmt.Println(Config.GetInt("maxBytes"), fmt.Sprintf("%T", Config.GetInt("maxBytes")))
 }
 ```
 
@@ -44,6 +46,7 @@ $ LOG_LEVEL=error go run main.go
 :8080
 myappname
 error
+3000000 int
 ```
 
 ### Logs

--- a/envcfg/envcfg.go
+++ b/envcfg/envcfg.go
@@ -3,7 +3,9 @@ package envcfg
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -26,9 +28,19 @@ func (c *config) Get(key string) string {
 	if configValue, exists := c.parsedConfigs[key]; exists {
 		return configValue
 	} else {
-		fmt.Sprintf("Unexpected config, returning empty string: %v", key)
+		fmt.Println(fmt.Sprintf("Unexpected config, returning empty string: %v", key))
 		return ""
 	}
+}
+
+func (c *config) GetInt(key string) int {
+	value, err := strconv.ParseInt(c.Get(key), 10, 64)
+
+	if err != nil {
+		log.Fatalf("Key value cannot be casted to int: %v", key)
+	}
+
+	return int(value)
 }
 
 // Bundled configs (ENVIRONMENT, LOG_LEVEL and VERSION) only, useful for brand new applications that has no extra confs.

--- a/envcfg/envcfg_test.go
+++ b/envcfg/envcfg_test.go
@@ -68,3 +68,14 @@ func TestCustomConfigs(t *testing.T) {
 		t.Errorf("==> Bundled config default took precedence over custom ones: '%v'", config.Get("logLevel"))
 	}
 }
+
+func TestGetInt(t *testing.T) {
+	t.Log("Returns casted int from config")
+
+	config := Load(Map{"MY_ENV_VAR": "30000"})
+
+	if config.GetInt("myEnvVar") != 30000 {
+		t.Errorf("==> GetInt config didn't casted value: %v", config.Get("myEnvVar"))
+	}
+	os.Unsetenv("MY_ENV_VAR") // Teardown
+}

--- a/envcfg/example_envcfg_test.go
+++ b/envcfg/example_envcfg_test.go
@@ -10,13 +10,16 @@ func ExampleLoad() {
 	Config := envcfg.Load(envcfg.Map{
 		"APPLICATION": "myappname",
 		"LISTEN_PORT": ":8080",
+		"MAX_BYTES":   "300000",
 	})
 
 	fmt.Println(Config.Get("listenPort"))
 	fmt.Println(Config.Get("logLevel"))
+	fmt.Println(Config.Get("maxBytes"), fmt.Sprintf("%T", Config.GetInt("maxBytes")))
 	// Output:
 	// :8080
 	// debug
+	// 300000 int
 }
 
 func ExampleLoadBundled() {


### PR DESCRIPTION
Very often libraries uses `int` type for configuration entries, this
commit introduces a handy funtion into `envcfg.Config` to cast
environment variable to `int` when `GetInt` function is deliberately
called.