### PR TITLE
Add `GetFloat`, `GetFloat64` and `GetInt64`

### DIFF
--- a/envcfg/envcfg.go
+++ b/envcfg/envcfg.go
@@ -33,14 +33,32 @@ func (c *config) Get(key string) string {
 	}
 }
 
-func (c *config) GetInt(key string) int {
+func (c *config) GetInt64(key string) int64 {
 	value, err := strconv.ParseInt(c.Get(key), 10, 64)
 
 	if err != nil {
 		log.Fatalf("Key value cannot be casted to int: %v", key)
 	}
 
-	return int(value)
+	return value
+}
+
+func (c *config) GetInt(key string) int {
+	return int(c.GetInt64(key))
+}
+
+func (c *config) GetFloat64(key string) float64 {
+	value, err := strconv.ParseFloat(c.Get(key), 64)
+
+	if err != nil {
+		log.Fatalf("Key value cannot be casted to float: %v", key)
+	}
+
+	return value
+}
+
+func (c *config) GetFloat(key string) float32 {
+	return float32(c.GetFloat64(key))
 }
 
 // Bundled configs (ENVIRONMENT, LOG_LEVEL and VERSION) only, useful for brand new applications that has no extra confs.

--- a/envcfg/envcfg_test.go
+++ b/envcfg/envcfg_test.go
@@ -79,3 +79,36 @@ func TestGetInt(t *testing.T) {
 	}
 	os.Unsetenv("MY_ENV_VAR") // Teardown
 }
+
+func TestGetFloat(t *testing.T) {
+	t.Log("Returns casted float from config")
+
+	config := Load(Map{"MY_ENV_VAR": "30.5"})
+
+	if config.GetFloat("myEnvVar") != float32(30.5) {
+		t.Errorf("==> GetInt config didn't casted value: %v", config.Get("myEnvVar"))
+	}
+	os.Unsetenv("MY_ENV_VAR") // Teardown
+}
+
+func TestGetInt64(t *testing.T) {
+	t.Log("Returns casted int from config")
+
+	config := Load(Map{"MY_ENV_VAR": "30000"})
+
+	if config.GetInt64("myEnvVar") != int64(30000) {
+		t.Errorf("==> GetInt config didn't casted value: %v", config.Get("myEnvVar"))
+	}
+	os.Unsetenv("MY_ENV_VAR") // Teardown
+}
+
+func TestGetFloat64(t *testing.T) {
+	t.Log("Returns casted float from config")
+
+	config := Load(Map{"MY_ENV_VAR": "30.5"})
+
+	if config.GetFloat64("myEnvVar") != float64(30.5) {
+		t.Errorf("==> GetInt config didn't casted value: %v", config.Get("myEnvVar"))
+	}
+	os.Unsetenv("MY_ENV_VAR") // Teardown
+}


### PR DESCRIPTION
Handy functions to easily access environment configurations that are
numbers.